### PR TITLE
修复竖屏模式下鼠标移动导致画面跟随

### DIFF
--- a/app/src/main/java/com/limelight/ui/StreamView.java
+++ b/app/src/main/java/com/limelight/ui/StreamView.java
@@ -138,6 +138,11 @@ public class StreamView extends SurfaceView {
         translateX = Math.max(-width / 2.0f, Math.min(width / 2.0f, translateX));
         translateY = Math.max(-height / 2.0f, Math.min(height / 2.0f, translateY));
 
+        // 当画面高度不足以占满可用区域时，保持居中不允许垂直位移
+        if (height <= screenHeight - keyboardHeight) {
+            translateY = 0;
+        }
+
         applyTransformation();
     }
 


### PR DESCRIPTION
## 概要
- 当竖屏画面高度未占满屏幕或弹出输入法时，鼠标上下移动会使画面跟随移动
- 修改 `StreamView` 中的 `setTranslationOffset`，在画面高度不足时保持垂直居中，避免不必要的位移

## 测试
- `./gradlew assembleDebug` *(失败：缺少 Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6885f41938888320b63afb61b4152c90