### PR TITLE
Add portrait streaming mode

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -2783,6 +2783,18 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // Update GameManager state to indicate we're in game
                 UiHelper.notifyStreamConnected(Game.this);
 
+                // 如果启用了竖屏模式并且设置了自动唤起输入法，则自动唤起输入法
+                if (prefConfig.portraitStream && prefConfig.portraitAutoKeyboard) {
+                    // 延迟一点时间确保串流已完全建立
+                    Handler keyboardHandler = new Handler();
+                    keyboardHandler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            toggleKeyboard();
+                        }
+                    }, 1000); // 1秒后自动唤起输入法
+                }
+
                 hideSystemUi(1000);
             }
         });

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -3118,7 +3118,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
     @Override
     public void showGameMenu(GameInputDevice device) {
-        if (controllerManager != null){
+        if (controllerManager != null && !prefConfig.preferGameMenu){
             controllerManager.getSuperPagesController().returnOperation();
         } else {
             new GameMenu(this, app, conn, device);

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -670,6 +670,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private void setPreferredOrientationForCurrentDisplay() {
         Display display = getWindowManager().getDefaultDisplay();
 
+        if (prefConfig.portraitStream) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+            return;
+        }
+
         // 如果反转分辨率但不影响服务器，允许任意方向，让内容按比例缩放
         if (prefConfig.reverseResolution && !prefConfig.reverseResolutionAffectServer) {
             // 允许任意方向，内容会根据服务器分辨率按比例显示
@@ -2859,6 +2864,18 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
         surfaceCreated = true;
 
+        if (prefConfig.portraitStream) {
+            DisplayMetrics metrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(metrics);
+            int screenWidth = metrics.widthPixels;
+            int streamWidth = prefConfig.width;
+            if (prefConfig.reverseResolution && !prefConfig.reverseResolutionAffectServer) {
+                streamWidth = prefConfig.originalWidth;
+            }
+            float scale = (float) screenWidth / (float) streamWidth;
+            streamView.setScaleFactor(scale);
+        }
+
         // Android will pick the lowest matching refresh rate for a given frame rate value, so we want
         // to report the true FPS value if refresh rate reduction is enabled. We also report the true
         // FPS value if there's no suitable matching refresh rate. In that case, Android could try to
@@ -3189,6 +3206,16 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         ViewGroup.LayoutParams layoutParams = streamView.getLayoutParams();
         if (layoutParams instanceof FrameLayout.LayoutParams) {
             FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) layoutParams;
+
+            if (prefConfig.portraitStream) {
+                params.gravity = Gravity.TOP | Gravity.CENTER_HORIZONTAL;
+                params.topMargin = 0;
+                params.leftMargin = 0;
+                params.rightMargin = 0;
+                params.bottomMargin = 0;
+                streamView.setLayoutParams(params);
+                return;
+            }
             
             // 根据屏幕位置设置重力属性
             switch (config.screenPosition) {

--- a/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.java
@@ -107,12 +107,25 @@ public class RelativeTouchContext implements TouchContext {
         this.targetView = view;
         this.prefConfig = prefConfig;
         this.handler = new Handler(Looper.getMainLooper());
+        
+        // 初始化当前缩放比率为StreamView的实际缩放比率
+        if (view instanceof StreamView) {
+            this.curScale = ((StreamView) view).getScaleFactor();
+        }
     }
 
     @Override
     public int getActionIndex()
     {
         return actionIndex;
+    }
+
+    /**
+     * 更新当前缩放比率
+     * @param scale 新的缩放比率
+     */
+    public void updateCurrentScale(float scale) {
+        this.curScale = scale;
     }
 
     private boolean isWithinTapBounds(int touchX, int touchY)

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -97,6 +97,7 @@ public class PreferenceConfiguration {
     static final String EXPORT_CONFIG_STRING = "export_super_config";
     static final String MERGE_CONFIG_STRING = "merge_super_config";
     static final String ABOUT_AUTHOR = "about_author";
+    private static final String PREFER_GAME_MENU_PREF_STRING = "checkbox_prefer_game_menu";
 
     static final String DEFAULT_RESOLUTION = "1920x1080";
     static final String DEFAULT_FPS = "60";
@@ -127,6 +128,7 @@ public class PreferenceConfiguration {
     private static final int DEFAULT_VIBRATE_FALLBACK_STRENGTH = 100;
     private static final boolean DEFAULT_FLIP_FACE_BUTTONS = false;
     private static final boolean DEFAULT_TOUCHSCREEN_TRACKPAD = true;
+    private static final boolean DEFAULT_PREFER_GAME_MENU = false;
     private static final String DEFAULT_AUDIO_CONFIG = "2"; // Stereo
     private static final boolean DEFAULT_LATENCY_TOAST = false;
     private static final String DEFAULT_FRAME_PACING = "latency";
@@ -241,6 +243,7 @@ public class PreferenceConfiguration {
     public boolean gamepadMotionSensorsFallbackToDevice;
     public boolean reverseResolution;
     public boolean reverseResolutionAffectServer;
+    public boolean preferGameMenu;
 
     public ScreenPosition screenPosition;
     public int screenOffsetX;
@@ -663,6 +666,7 @@ public class PreferenceConfiguration {
         config.gamepadMotionSensors = prefs.getBoolean(GAMEPAD_MOTION_SENSORS_PREF_STRING, DEFAULT_GAMEPAD_MOTION_SENSORS);
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
         config.enableSimplifyPerfOverlay = false;
+        config.preferGameMenu = prefs.getBoolean(PREFER_GAME_MENU_PREF_STRING, DEFAULT_PREFER_GAME_MENU);
 
         config.reverseResolution = prefs.getBoolean(REVERSE_RESOLUTION_PREF_STRING, DEFAULT_REVERSE_RESOLUTION);
         config.reverseResolutionAffectServer = prefs.getBoolean(REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING, DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER);
@@ -770,6 +774,7 @@ public class PreferenceConfiguration {
                     .putBoolean(ENABLE_PERF_OVERLAY_STRING, enablePerfOverlay)
                     .putBoolean(REVERSE_RESOLUTION_PREF_STRING, reverseResolution)
                     .putBoolean(REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING, reverseResolutionAffectServer)
+                    .putBoolean(PREFER_GAME_MENU_PREF_STRING, preferGameMenu)
                     .putString(SCREEN_POSITION_PREF_STRING, positionString)
                     .putInt(SCREEN_OFFSET_X_PREF_STRING, screenOffsetX)
                     .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -170,6 +170,8 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_PORTRAIT_STREAM = false;
     private static final String PORTRAIT_STREAM_SCALE_PREF_STRING = "seekbar_portrait_stream_scale";
     private static final int DEFAULT_PORTRAIT_STREAM_SCALE = 100;
+    private static final String PORTRAIT_AUTO_KEYBOARD_PREF_STRING = "checkbox_portrait_auto_keyboard";
+    private static final boolean DEFAULT_PORTRAIT_AUTO_KEYBOARD = true;
 
     // 画面位置常量
     private static final String SCREEN_POSITION_PREF_STRING = "list_screen_position";
@@ -250,6 +252,7 @@ public class PreferenceConfiguration {
     public int screenOffsetY;
     public boolean portraitStream;
     public int portraitStreamScale;
+    public boolean portraitAutoKeyboard;
 
     public static boolean isNativeResolution(int width, int height) {
         // 使用集合检查是否为原生分辨率
@@ -672,6 +675,7 @@ public class PreferenceConfiguration {
         config.reverseResolutionAffectServer = prefs.getBoolean(REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING, DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER);
         config.portraitStream = prefs.getBoolean(PORTRAIT_STREAM_PREF_STRING, DEFAULT_PORTRAIT_STREAM);
         config.portraitStreamScale = prefs.getInt(PORTRAIT_STREAM_SCALE_PREF_STRING, DEFAULT_PORTRAIT_STREAM_SCALE);
+        config.portraitAutoKeyboard = prefs.getBoolean(PORTRAIT_AUTO_KEYBOARD_PREF_STRING, DEFAULT_PORTRAIT_AUTO_KEYBOARD);
 
         // 如果启用了分辨率反转，则交换宽度和高度（仅用于本地屏幕方向控制）
         if (config.reverseResolution) {
@@ -780,6 +784,7 @@ public class PreferenceConfiguration {
                     .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)
                     .putBoolean(PORTRAIT_STREAM_PREF_STRING, portraitStream)
                     .putInt(PORTRAIT_STREAM_SCALE_PREF_STRING, portraitStreamScale)
+                    .putBoolean(PORTRAIT_AUTO_KEYBOARD_PREF_STRING, portraitAutoKeyboard)
                     .apply();
             return true;
         } catch (Exception e) {
@@ -806,6 +811,7 @@ public class PreferenceConfiguration {
         copy.screenOffsetY = this.screenOffsetY;
         copy.portraitStream = this.portraitStream;
         copy.portraitStreamScale = this.portraitStreamScale;
+        copy.portraitAutoKeyboard = this.portraitAutoKeyboard;
         return copy;
     }
 }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -164,6 +164,8 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_REVERSE_RESOLUTION = false;
     private static final String REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING = "checkbox_reverse_resolution_affect_server";
     private static final boolean DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER = false;
+    private static final String PORTRAIT_STREAM_PREF_STRING = "checkbox_portrait_stream";
+    private static final boolean DEFAULT_PORTRAIT_STREAM = false;
 
     // 画面位置常量
     private static final String SCREEN_POSITION_PREF_STRING = "list_screen_position";
@@ -241,6 +243,7 @@ public class PreferenceConfiguration {
     public ScreenPosition screenPosition;
     public int screenOffsetX;
     public int screenOffsetY;
+    public boolean portraitStream;
 
     public static boolean isNativeResolution(int width, int height) {
         // 使用集合检查是否为原生分辨率
@@ -660,6 +663,7 @@ public class PreferenceConfiguration {
 
         config.reverseResolution = prefs.getBoolean(REVERSE_RESOLUTION_PREF_STRING, DEFAULT_REVERSE_RESOLUTION);
         config.reverseResolutionAffectServer = prefs.getBoolean(REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING, DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER);
+        config.portraitStream = prefs.getBoolean(PORTRAIT_STREAM_PREF_STRING, DEFAULT_PORTRAIT_STREAM);
 
         // 如果启用了分辨率反转，则交换宽度和高度（仅用于本地屏幕方向控制）
         if (config.reverseResolution) {
@@ -765,6 +769,7 @@ public class PreferenceConfiguration {
                     .putString(SCREEN_POSITION_PREF_STRING, positionString)
                     .putInt(SCREEN_OFFSET_X_PREF_STRING, screenOffsetX)
                     .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)
+                    .putBoolean(PORTRAIT_STREAM_PREF_STRING, portraitStream)
                     .apply();
             return true;
         } catch (Exception e) {
@@ -789,6 +794,7 @@ public class PreferenceConfiguration {
         copy.screenPosition = this.screenPosition;
         copy.screenOffsetX = this.screenOffsetX;
         copy.screenOffsetY = this.screenOffsetY;
+        copy.portraitStream = this.portraitStream;
         return copy;
     }
 }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -166,6 +166,8 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER = false;
     private static final String PORTRAIT_STREAM_PREF_STRING = "checkbox_portrait_stream";
     private static final boolean DEFAULT_PORTRAIT_STREAM = false;
+    private static final String PORTRAIT_STREAM_SCALE_PREF_STRING = "seekbar_portrait_stream_scale";
+    private static final int DEFAULT_PORTRAIT_STREAM_SCALE = 100;
 
     // 画面位置常量
     private static final String SCREEN_POSITION_PREF_STRING = "list_screen_position";
@@ -244,6 +246,7 @@ public class PreferenceConfiguration {
     public int screenOffsetX;
     public int screenOffsetY;
     public boolean portraitStream;
+    public int portraitStreamScale;
 
     public static boolean isNativeResolution(int width, int height) {
         // 使用集合检查是否为原生分辨率
@@ -664,6 +667,7 @@ public class PreferenceConfiguration {
         config.reverseResolution = prefs.getBoolean(REVERSE_RESOLUTION_PREF_STRING, DEFAULT_REVERSE_RESOLUTION);
         config.reverseResolutionAffectServer = prefs.getBoolean(REVERSE_RESOLUTION_AFFECT_SERVER_PREF_STRING, DEFAULT_REVERSE_RESOLUTION_AFFECT_SERVER);
         config.portraitStream = prefs.getBoolean(PORTRAIT_STREAM_PREF_STRING, DEFAULT_PORTRAIT_STREAM);
+        config.portraitStreamScale = prefs.getInt(PORTRAIT_STREAM_SCALE_PREF_STRING, DEFAULT_PORTRAIT_STREAM_SCALE);
 
         // 如果启用了分辨率反转，则交换宽度和高度（仅用于本地屏幕方向控制）
         if (config.reverseResolution) {
@@ -770,6 +774,7 @@ public class PreferenceConfiguration {
                     .putInt(SCREEN_OFFSET_X_PREF_STRING, screenOffsetX)
                     .putInt(SCREEN_OFFSET_Y_PREF_STRING, screenOffsetY)
                     .putBoolean(PORTRAIT_STREAM_PREF_STRING, portraitStream)
+                    .putInt(PORTRAIT_STREAM_SCALE_PREF_STRING, portraitStreamScale)
                     .apply();
             return true;
         } catch (Exception e) {
@@ -795,6 +800,7 @@ public class PreferenceConfiguration {
         copy.screenOffsetX = this.screenOffsetX;
         copy.screenOffsetY = this.screenOffsetY;
         copy.portraitStream = this.portraitStream;
+        copy.portraitStreamScale = this.portraitStreamScale;
         return copy;
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -342,4 +342,8 @@
     <string name="summary_analog_scrolling">在鼠标模式下选择用哪个摇杆控制鼠标移动</string>
     <string name="summary_seekbar_vibrate_fallback_strength">增强或减弱设备的震动强度</string>
     <string name="analogscroll_none">默认 (两个摇杆都控制鼠标)</string>
+    
+    <!-- 优先显示游戏菜单选项 -->
+    <string name="title_checkbox_prefer_game_menu">优先显示游戏菜单</string>
+    <string name="summary_checkbox_prefer_game_menu">启用后，返回按钮将显示传统游戏菜单而非王冠超级功能菜单</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -365,4 +365,8 @@
     <string name="analogscroll_none">None (both sticks move the mouse)</string>
     <string name="analogscroll_right">Right analog stick</string>
     <string name="analogscroll_left">Left analog stick</string>
+    
+    <!-- Prefer game menu option -->
+    <string name="title_checkbox_prefer_game_menu">Prefer Game Menu</string>
+    <string name="summary_checkbox_prefer_game_menu">When enabled, the back button will show the traditional game menu instead of the Crown Super Features menu</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -76,6 +76,18 @@
             android:title="竖屏串流模式"
             android:summary="以竖屏方式播放串流画面，画面位于屏幕顶部"
             android:defaultValue="false" />
+        <com.limelight.preferences.SeekBarPreference
+            android:key="seekbar_portrait_stream_scale"
+            android:title="竖屏模式初始缩放比率"
+            android:summary="设置竖屏串流模式下的初始界面缩放比率"
+            android:dialogMessage="调整竖屏串流模式下的初始界面缩放比率"
+            seekbar:min="50"
+            android:max="1000"
+            android:defaultValue="100"
+            seekbar:step="5"
+            seekbar:keyStep="10"
+            android:text="%"
+            android:dependency="checkbox_portrait_stream" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="画面位置设置"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -71,6 +71,11 @@
             android:summary="启用后，传给服务器的分辨率也会被反转"
             android:defaultValue="false"
             android:dependency="checkbox_reverse_resolution" />
+        <CheckBoxPreference
+            android:key="checkbox_portrait_stream"
+            android:title="竖屏串流模式"
+            android:summary="以竖屏方式播放串流画面，画面位于屏幕顶部"
+            android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="画面位置设置"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -347,6 +347,12 @@
             android:key="checkbox_show_onscreen_keyboard"
             android:summary="串流中自定义按键和一些设置，并将这些保存到自定义可快速切换的配置中"
             android:title="王冠的超级功能" />
+        <CheckBoxPreference
+            android:key="checkbox_prefer_game_menu"
+            android:title="@string/title_checkbox_prefer_game_menu"
+            android:summary="@string/summary_checkbox_prefer_game_menu"
+            android:defaultValue="false"
+            android:dependency="checkbox_show_onscreen_keyboard" />
         <ListPreference
             android:key="export_super_config"
             android:title="导出配置"


### PR DESCRIPTION
## Summary
- add `portraitStream` option to `PreferenceConfiguration`
- anchor stream view to top of screen when portrait mode is enabled
- scale stream to screen width in portrait mode
- expose new setting `竖屏串流模式` in preferences

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688603a24208832089d7e0b6696ae389